### PR TITLE
Allow to pass request headers to action call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,12 @@ module.exports = {
 					route.authorization = true;
 			}
 
+			route.attachHeaders = opts.attachHeaders ? true : false;
+
+			route.attachHeadersKey = "_reqHeaders";
+			if (opts.attachHeadersKey) {
+				route.attachHeadersKey = opts.attachHeadersKey;
+			}
 
 			// Handle whitelist
 			route.whitelist = opts.whitelist;
@@ -303,6 +309,16 @@ module.exports = {
 				params = Object.assign({}, query);
 				if (_.isObject(req.body)) 
 					params = Object.assign(params, req.body);
+			})
+
+			// Attach headers to params
+			.then(() => {
+				if (route.attachHeaders) {
+					let headers = {};
+					headers[route.attachHeadersKey] = req.headers;
+
+					params = Object.assign(params, headers);
+				}
 			})
 
 			// Resolve action by name


### PR DESCRIPTION
Hello @icebob,

I need in my project to pass request headers into context of call action so I created a small change that allows to put them there. I'm aware that this change missing tests (small but it always good to have some automated test to check if it's broken anything) Please tell me what you think about this, cheers!