### PR TITLE
Named parameter in aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+<a name="0.3.0"></a>
+# 0.3.0 (2017-06-01)
+
+## New
+
+### Named parameters in aliases
+It is possible to use named parameters in aliases. Named paramters are defined by prefixing a colon to the parameter name (`:name`)
+
+**Usage**
+```js
+broker.createService(ApiGatewayService, {
+    settings: {
+        routes: [{
+            path: "/api",
+
+            aliases: {
+                "GET greeter/:name": "test.greeter",
+                "optinal-param/:name?": "test.echo",
+                "repeat-param/:args*": "test.echo",
+                "GET /": "test.hello"                
+            }
+        }]
+    }
+});
+
+// Start server
+broker.start();
+```
+
+Example: [examples/full](/examples/full)
+
+-----------------------------
 <a name="0.2.2"></a>
 # 0.2.2 (2017-06-01)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `moleculer-web` is the official API gateway service for [Moleculer](https://
 * support HTTP & HTTPS
 * serve static files
 * multiple routes
-* alias names
+* alias names (with named parameters)
 * whitelist
 * multiple body parsers (json, urlencoded)
 * before & after call hooks

--- a/examples/full/index.js
+++ b/examples/full/index.js
@@ -22,6 +22,9 @@
  * 	
  *  - API: Add two numbers (use alias name)
  * 		https://localhost:4000/api/add?a=25&b=13
+ * 
+ * 	- or with named parameters
+ * 		https://localhost:4000/api/add/25/13
  * 	
  *  - API: Divide two numbers with validation
  * 		https://localhost:4000/api/math/div?a=25&b=13
@@ -143,6 +146,7 @@ broker.createService({
 				aliases: {
 					"login": "auth.login",
 					"add": "math.add",
+					"add/:a/:b": "math.add",
 					"GET sub": "math.sub",
 					"POST divide": "math.div",
 				},

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "isstream": "0.1.2",
     "lodash": "4.17.4",
     "nanomatch": "1.2.0",
+    "path-to-regexp": "1.7.0",
     "serve-static": "1.12.3"
   },
   "engines": {

--- a/src/errors.js
+++ b/src/errors.js
@@ -10,6 +10,7 @@ const { MoleculerError } = require("moleculer").Errors;
 
 const ERR_NO_TOKEN = "ERR_NO_TOKEN";
 const ERR_INVALID_TOKEN = "ERR_INVALID_TOKEN";
+const ERR_UNABLE_DECODE_PARAM = "ERR_UNABLE_DECODE_PARAM";
 
 /**
  * Invalid request body
@@ -123,5 +124,6 @@ module.exports = {
 	BadRequestError,
 
 	ERR_NO_TOKEN,
-	ERR_INVALID_TOKEN
+	ERR_INVALID_TOKEN,
+	ERR_UNABLE_DECODE_PARAM
 };

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ function decodeParam(param) {
 	try {
 		return decodeURIComponent(param);
 	} catch (_) {
+		/* istanbul ignore next */
 		throw BadRequestError(ERR_UNABLE_DECODE_PARAM, { param });
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -147,8 +147,6 @@ module.exports = {
 			route.path = (this.settings.path || "") + (opts.path || "");
 			route.path = route.path || "/";
 
-			//route.urlRegex = new RegExp(route.path.replace("/", "\\/") + "\\/([\\w\\.\\~\\/]+)", "g");
-
 			// Handle aliases
 			if (opts.aliases && Object.keys(opts.aliases).length > 0) {
 				route.aliases = [];
@@ -159,6 +157,9 @@ module.exports = {
 						method = p[0];
 						matchPath = p[1];
 					}
+					if (matchPath.startsWith("/"))
+						matchPath = matchPath.slice(1);
+
 					let keys = [];
 					const re = pathToRegexp(matchPath, keys, {}); // Options: https://github.com/pillarjs/path-to-regexp#usage
 
@@ -236,21 +237,16 @@ module.exports = {
 				if (this.routes && this.routes.length > 0) {
 					for(let i = 0; i < this.routes.length; i++) {
 						const route = this.routes[i];
-						/*
-						this.urlRegex.lastIndex = 0;
-						const match = this.urlRegex.exec(url);
-						if (match) {
-						*/
+
 						if (url.startsWith(route.path)) {
 							// Resolve action name
-							//let actionName = match[1].replace(/~/, "$").replace(/\//g, ".");
-							let actionName = url.slice(route.path.length);
-							if (actionName.startsWith("/"))
-								actionName = actionName.slice(1);
+							let urlPath = url.slice(route.path.length);
+							if (urlPath.startsWith("/"))
+								urlPath = urlPath.slice(1);
 
-							actionName = actionName.replace(/~/, "$");
+							urlPath = urlPath.replace(/~/, "$");
 
-							return this.callAction(route, actionName, req, res, query);
+							return this.callAction(route, urlPath, req, res, query);
 						} 
 					}
 				}

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -534,7 +534,11 @@ describe("Test alias", () => {
 				aliases: {
 					"add": "math.add",
 					"GET hello": "test.hello",
-					"POST hello": "test.greeter"
+					"POST hello": "test.greeter",
+					"GET greeter/:name": "test.greeter",
+					"opt-test/:name?": "test.echo",
+					"repeat-test/:args*": "test.echo",
+					"GET /": "test.hello"
 				}
 			}]
 		});
@@ -542,7 +546,7 @@ describe("Test alias", () => {
 		broker.loadService("./test/services/math.service");
 	});
 
-
+	
 	it("GET /api/math.add", () => {
 		return request(server)
 			.get("/api/math.add")
@@ -608,6 +612,75 @@ describe("Test alias", () => {
 			});		
 	});	
 
+	it("GET /api/greeter/Norbert", () => {
+		return request(server)
+			.get("/api/greeter/Norbert")
+			.expect(200)
+			.expect("Content-Type", "application/json")
+			.then(res => {
+				expect(res.body).toBe("Hello Norbert");
+			});		
+	});	
+
+	it("POST /api/greeter/Norbert", () => {
+		return request(server)
+			.post("/api/greeter/Norbert")
+			.expect(501)
+			.expect("Content-Type", "application/json")
+			.then(res => {
+				expect(res.body).toEqual({
+					"name": "ServiceNotFoundError", 
+					"message": "Service 'greeter.Norbert' is not available!", 
+					"code": 501, 
+					"type": null,
+					"data": {"action": "greeter.Norbert"}
+				});
+			});		
+	});	
+
+	it("GET opt-test/:name? with name", () => {
+		return request(server)
+			.get("/api/opt-test/John")
+			.expect(200)
+			.expect("Content-Type", "application/json")
+			.then(res => {
+				expect(res.body.params).toEqual({
+					name: "John"
+				});
+			});		
+	});	
+
+	it("GET opt-test/:name? without name", () => {
+		return request(server)
+			.get("/api/opt-test")
+			.expect(200)
+			.expect("Content-Type", "application/json")
+			.then(res => {
+				expect(res.body.params).toEqual({});
+			});		
+	});	
+
+	it("GET repeat-test/:args?", () => {
+		return request(server)
+			.get("/api/repeat-test/John/Jane/Adam/Walter")
+			.expect(200)
+			.expect("Content-Type", "application/json")
+			.then(res => {
+				expect(res.body.params).toEqual({
+					args: ["John", "Jane", "Adam", "Walter"]
+				});
+			});		
+	});
+
+	it("GET /api/", () => {
+		return request(server)
+			.get("/api")
+			.expect(200)
+			.expect("Content-Type", "application/json")
+			.then(res => {
+				expect(res.body).toBe("Hello Moleculer");
+			});
+	});		
 });
 
 describe("Test alias & whitelist", () => {

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -534,10 +534,10 @@ describe("Test alias", () => {
 				aliases: {
 					"add": "math.add",
 					"GET hello": "test.hello",
-					"POST hello": "test.greeter",
+					"POST /hello": "test.greeter",
 					"GET greeter/:name": "test.greeter",
 					"opt-test/:name?": "test.echo",
-					"repeat-test/:args*": "test.echo",
+					"/repeat-test/:args*": "test.echo",
 					"GET /": "test.hello"
 				}
 			}]


### PR DESCRIPTION
It is possible to use named parameters in aliases. Named parameters are defined by prefixing a colon to the parameter name (`:name`)

**Usage**
```js
broker.createService(ApiGatewayService, {
    settings: {
        routes: [{
            path: "/api",

            aliases: {
                "GET greeter/:name": "test.greeter",
                "optinal-param/:name?": "test.echo",
                "repeat-param/:args*": "test.echo",
                "GET /": "test.hello"                
            }
        }]
    }
});

// Start server
broker.start();
```

Example: [examples/full](/examples/full)