### PR TITLE
Allowing the url "/" to match service actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -436,6 +436,10 @@ module.exports = {
 				if (url.length > 1 && url.endsWith("/"))
 					url = url.slice(0, -1);
 
+				// Handle root case
+				if (url === '')
+					url = '/'
+
 				// Check the URL
 				if (this.routes && this.routes.length > 0) {
 					for(let i = 0; i < this.routes.length; i++) {

--- a/src/index.js
+++ b/src/index.js
@@ -437,8 +437,8 @@ module.exports = {
 					url = url.slice(0, -1);
 
 				// Handle root case
-				if (url === '')
-					url = '/'
+				if (url === "")
+					url = "/";
 
 				// Check the URL
 				if (this.routes && this.routes.length > 0) {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -864,6 +864,32 @@ describe("Test aliases", () => {
 	});
 });
 
+describe("Test root url alias", () => {
+	let broker;
+	let service;
+	let server;
+
+	beforeAll(() => {
+		[ broker, service, server] = setup({
+			routes: [{
+				aliases: {
+					"": "test.hello"
+				}
+			}]
+		})
+	})
+
+	it ("GET /", () => {
+		return request(server)
+			.get("/")
+			.expect(200)
+			.expect("Content-Type", "application/json; charset=utf-8")
+			.then(res => {
+				expect(res.body).toEqual("Hello Moleculer");
+			});
+	})
+})
+
 describe("Test REST shorthand aliases", () => {
 	let broker;
 	let service;


### PR DESCRIPTION
Prior to this PR, moleculer-web did not allow the url "/" to be mapped to any service actions.  This PR changes that so any service action with no path, or the path of / can be mapped appropriately.